### PR TITLE
docs: suggest adding more benchmark tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ What's special about the system:
 
 ![Light benchmark analysis](light_benchmark/analysis.png)
 
+The current benchmark is an initial case study. See the
+[benchmark coverage proposal](benchmarks/README.md) for ideas on testing more
+tasks and AI providers.
+
 ## 3. More details 
 
 Send these exact commands to Codex from the relevant project directory:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,26 @@
+# More benchmark coverage
+
+The existing [light benchmark](../light_benchmark/README.md) is a useful first
+test of `codex_workflow`. Adding more benchmarks would give a clearer picture of
+how well the workflow performs in different situations.
+
+More tests also increase the probability of finding weaknesses and useful
+improvements. Different tasks and AI providers may expose problems in routing,
+coordination, context handoffs, token usage, or tool use that a single benchmark
+cannot reveal.
+
+Useful additions could include:
+
+- different task types, such as bug fixes, features, refactors, and research;
+- small and large repositories;
+- short tasks and long-context tasks;
+- more models and AI providers, including OpenAI, Anthropic, Google, xAI, Z.AI,
+  and local/open-weight models;
+- comparisons between no workflow and the Light, Medium, and Heavy routes.
+
+To keep comparisons useful, each benchmark should use the same task, prompt,
+tools, and acceptance checks whenever possible. Results should record the exact
+model, provider, workflow version, completion status, time, and token usage.
+
+This broader coverage could help identify which parts of the workflow already
+work well and where future changes would have the greatest impact.


### PR DESCRIPTION
## Summary

The current light benchmark is a useful first test, but adding more benchmarks could give a clearer picture of how the workflow performs.

Testing different tasks, repository sizes, workflow routes, models, and AI providers may reveal weaknesses in coordination, context handling, token usage, and tool use. This increases the probability of finding useful improvements for the workflow.

The proposal also recommends keeping prompts, tools, and acceptance checks consistent so results remain comparable.

## Testing

- Token-report suite: 8 tests passed.
- Documentation diff check passed.
- The runtime suite has one existing unrelated failure because workflow_breakdown.md contains the retired phrase 'lifecycle parent'; the other 57 tests passed.